### PR TITLE
Fix selector for title on PR page

### DIFF
--- a/src/background.js
+++ b/src/background.js
@@ -27,7 +27,7 @@
         // Pull-Request listing page.
         const pullRequests = document.getElementsByClassName('js-issue-row');
         // Individual PR details page.
-        const detailsPageTitle = document.querySelectorAll('span.js-issue-title');
+        const detailsPageTitle = document.querySelectorAll('.js-issue-title');
         // Commits
         const commitListing = document.getElementsByClassName('commit-title');
 


### PR DESCRIPTION
Instead of `span` the element is now `bdi`. It felt safer to remove the element in the selector rather then to change it.